### PR TITLE
show document from type

### DIFF
--- a/lib/katakata_irb/type_simulator.rb
+++ b/lib/katakata_irb/type_simulator.rb
@@ -635,6 +635,8 @@ class KatakataIrb::TypeSimulator
       KatakataIrb::Types::OBJECT
     in [:redo | :retry]
       scope.terminate
+    in [:zsuper]
+      KatakataIrb::Types::OBJECT
     in [:super, args]
       args, kwargs, _block = retrieve_method_args args
       args.each do |arg|


### PR DESCRIPTION
`Reline.dig_perfect_match_proc` にはpreposing postposing が渡ってこないので解析できない
仕方がないから `Reline.completion_prpc` に渡ってきたものを使う(が呼ばれる順序がperfect_match→completionなのでちょっと不便)
