### PR TITLE
Scope refactor

### DIFF
--- a/lib/katakata_irb/scope.rb
+++ b/lib/katakata_irb/scope.rb
@@ -166,10 +166,8 @@ module KatakataIrb
     def merge_jumps
       if terminated?
         @terminated = false
-        prev_changes = @changes
         @changes = @mergeable_changes
         merge @jump_branches
-        @changes = prev_changes
         @terminated = true
       else
         merge [*@jump_branches, {}]

--- a/lib/katakata_irb/scope.rb
+++ b/lib/katakata_irb/scope.rb
@@ -3,10 +3,23 @@ require_relative 'types'
 
 module KatakataIrb
   class BaseScope
+    SELF = '%self'
+    BREAK_RESULT = '%break'
+    NEXT_RESULT = '%next'
+    RETURN_RESULT = '%return'
+    PATTERNMATCH_BREAK = '%match'
+    RAISE_BREAK = '%raise'
+
     def initialize(binding, self_object)
       @binding, @self_object = binding, self_object
-      @cache = { Scope::SELF => KatakataIrb::Types.type_from_object(self_object) }
+      @cache = { SELF => KatakataIrb::Types.type_from_object(self_object) }
       @local_variables = binding.local_variables.map(&:to_s).to_set
+    end
+
+    def level() = 0
+
+    def level_of(name)
+      has?(name) ? 0 : nil
     end
 
     def mutable?() = false
@@ -28,7 +41,7 @@ module KatakataIrb
     end
 
     def self_type
-      self[Scope::SELF]
+      self[SELF]
     end
 
     def local_variables
@@ -65,27 +78,22 @@ module KatakataIrb
     end
   end
 
-  class Scope
-    SELF = '%self'
-    BREAK_RESULT = '%break'
-    NEXT_RESULT = '%next'
-    RETURN_RESULT = '%return'
-    PATTERNMATCH_BREAK = '%match'
-    RAISE_BREAK = '%raise'
-
-    attr_reader :parent, :jump_branches
+  class Scope < BaseScope
+    attr_reader :parent, :jump_branches, :mergeable_changes
 
     def self.from_binding(binding) = new(BaseScope.new(binding, binding.eval('self')))
 
     def initialize(parent, table = {}, trace_cvar: true, trace_ivar: true, trace_lvar: true, passthrough: false)
-      @tables = [table]
+      @table = table
       @parent = parent
+      @level = parent.level + (passthrough ? 0 : 1)
       @trace_cvar = trace_cvar
       @trace_ivar = trace_ivar
       @trace_lvar = trace_lvar
       @passthrough = passthrough
       @terminated = false
       @jump_branches = []
+      @mergeable_changes = @changes = table.transform_values { [level, _1] }
     end
 
     def mutable? = true
@@ -97,19 +105,23 @@ module KatakataIrb
     def terminate_with(type, value)
       return if terminated?
       self[type] = value
-      store_jump type
+      store_jump type, @mergeable_changes
       terminate
     end
 
-    def store_jump(type)
-      scopes = ancestors.select(&:mutable?)
-      scope = scopes.find { _1.has_own? type } || scopes.last
-      index = scopes.index scope
-      scope.jump_branches << scopes.drop(index).map(&:branch_table_clone)
+    def store_jump(type, changes)
+      raise unless changes
+      return if terminated?
+      if has_own?(type)
+        @jump_branches << changes
+      elsif @parent.mutable?
+        @parent.store_jump(type, changes)
+      end
     end
 
     def terminate
       @terminated = true
+      @changes = {}
     end
 
     def branch_table_clone() = @tables.last.dup
@@ -120,22 +132,22 @@ module KatakataIrb
       type == :cvar ? @trace_cvar : type == :ivar ? @trace_ivar : type == :lvar ? @trace_lvar : true
     end
 
-    def [](name)
-      @tables.reverse_each do |table|
-        return table[name] if table.key? name
-      end
-      @parent[name] if trace? name
+    def level_of(name)
+      has_own?(name) ? level : parent.level_of(name)
     end
 
-    def []=(name, type)
-      return if terminated?
-      if @passthrough && BaseScope.type_by_name(name) != :internal
-        @parent[name] = type
-      elsif trace?(name) && @parent.mutable? && !@tables.any? { _1.key? name } && @parent.has?(name)
-        @parent[name] = type
-      else
-        @tables.last[name] = type
+    def [](name)
+      level, value = @changes[name]
+      if level
+        value
+      elsif trace? name
+        @parent[name] if trace? name
       end
+    end
+
+    def []=(name, value)
+      variable_level = level_of(name) || level
+      @changes[name] = [variable_level, value]
     end
 
     def self_type
@@ -143,55 +155,42 @@ module KatakataIrb
     end
 
     def local_variables
-      lvar_keys = @tables.flat_map(&:keys).select do |name|
+      lvar_keys = @changes.keys.select do |name|
         BaseScope.type_by_name(name) == :lvar
       end
       lvar_keys |= @parent.local_variables if @trace_lvar
       lvar_keys
     end
 
-    def start_branch
-      @tables << {}
-    end
-
-    def end_branch
-      @tables.pop
-    end
-
     def merge_jumps
       if terminated?
         merge @jump_branches
       else
-        merge [*@jump_branches, [{}] * ancestors.size]
-      end
-    end
-
-    def merge_branch(tables)
-      target_table = @tables.last
-      keys = tables.flat_map(&:keys).uniq
-      keys.each do |key|
-        original_value = self[key]
-        target_table[key] = KatakataIrb::Types::UnionType[*tables.map { _1[key] || original_value }.compact.uniq]
+        merge [*@jump_branches, {}]
       end
     end
 
     def conditional(&block)
-      run_branches(block, ->(s){}).first || KatakataIrb::Types::NIL
+      run_branches(block, ->(_s) {}).first || KatakataIrb::Types::NIL
     end
 
     def never(&block)
-      branch(&block)
+      block.call Scope.new(self, { BREAK_RESULT => nil, NEXT_RESULT => nil, PATTERNMATCH_BREAK => nil, RETURN_RESULT => nil, RAISE_BREAK => nil }, passthrough: true)
     end
 
     def run_branches(*blocks)
-      results = blocks.map { branch(&_1) }.reject(&:last)
-      merge results.map { _2 }
-      if results.empty?
-        terminate
-        []
-      else
-        results.map(&:first)
+      results = []
+      branches = []
+      blocks.each do |block|
+        scope = Scope.new self, passthrough: true
+        result = block.call scope
+        next if scope.terminated?
+        results << result
+        branches << scope.mergeable_changes
       end
+      terminate if branches.empty?
+      merge branches
+      results
     end
 
     def has?(name)
@@ -199,30 +198,23 @@ module KatakataIrb
     end
 
     def has_own?(name)
-      @tables.any? { _1.key? name }
+      @changes.key? name
     end
 
-    private
-
-    def ancestors
-      scopes = [self]
-      scopes << scopes.last.parent while scopes.last.parent&.mutable?
-      scopes
-    end
-
-    def branch
-      scopes = ancestors
-      scopes.each(&:start_branch)
-      terminated_was = @terminated
-      result = yield self
-      terminated, @terminated = @terminated, terminated_was
-      [result, scopes.map(&:end_branch), terminated]
-    end
+    protected
 
     def merge(branches)
-      scopes = ancestors
-      scopes.zip(*branches).each do |scope, *tables|
-        scope.merge_branch(tables)
+      current_level = level
+      merge = {}
+      branches.each do |changes|
+        changes.each do |name, (level, value)|
+          next if current_level < level
+          (merge[name] ||= [level, []]).last << value
+        end
+      end
+      merge.each do |name, (level, values)|
+        values << self[name] unless values.size == branches.size
+        self[name] = KatakataIrb::Types::UnionType[*values.compact]
       end
     end
   end

--- a/lib/katakata_irb/scope.rb
+++ b/lib/katakata_irb/scope.rb
@@ -29,13 +29,13 @@ module KatakataIrb
         fallback = KatakataIrb::Types::NIL
         case BaseScope.type_by_name name
         when :cvar
-          KatakataIrb::TypeSimulator.type_of(fallback: fallback) { @self_object.class_variable_get name }
+          BaseScope.type_of(fallback: fallback) { @self_object.class_variable_get name }
         when :ivar
-          KatakataIrb::TypeSimulator.type_of(fallback: fallback) { @self_object.instance_variable_get name }
+          BaseScope.type_of(fallback: fallback) { @self_object.instance_variable_get name }
         when :lvar
-          KatakataIrb::TypeSimulator.type_of(fallback: fallback) { @binding.local_variable_get(name) }
+          BaseScope.type_of(fallback: fallback) { @binding.local_variable_get(name) }
         when :const
-          KatakataIrb::TypeSimulator.type_of(fallback: fallback) { @binding.eval name }
+          BaseScope.type_of(fallback: fallback) { @binding.eval name }
         end
       )
     end
@@ -46,6 +46,14 @@ module KatakataIrb
 
     def local_variables
       @local_variables.to_a
+    end
+
+    def self.type_of(fallback: KatakataIrb::Types::OBJECT)
+      begin
+        KatakataIrb::Types.type_from_object yield
+      rescue
+        fallback
+      end
     end
 
     def self.type_by_name(name)

--- a/lib/katakata_irb/scope.rb
+++ b/lib/katakata_irb/scope.rb
@@ -176,7 +176,7 @@ module KatakataIrb
     end
 
     def conditional(&block)
-      run_branches(block, -> {}).first || KatakataIrb::Types::NIL
+      run_branches(block, ->(s){}).first || KatakataIrb::Types::NIL
     end
 
     def never(&block)
@@ -214,7 +214,7 @@ module KatakataIrb
       scopes = ancestors
       scopes.each(&:start_branch)
       terminated_was = @terminated
-      result = yield
+      result = yield self
       terminated, @terminated = @terminated, terminated_was
       [result, scopes.map(&:end_branch), terminated]
     end

--- a/lib/katakata_irb/scope.rb
+++ b/lib/katakata_irb/scope.rb
@@ -121,7 +121,7 @@ module KatakataIrb
     def terminate
       return if terminated?
       @terminated = true
-      @changes = {}
+      @changes = @mergeable_changes.dup
     end
 
     def branch_table_clone() = @tables.last.dup
@@ -165,7 +165,12 @@ module KatakataIrb
 
     def merge_jumps
       if terminated?
+        @terminated = false
+        prev_changes = @changes
+        @changes = @mergeable_changes
         merge @jump_branches
+        @changes = prev_changes
+        @terminated = true
       else
         merge [*@jump_branches, {}]
       end

--- a/lib/katakata_irb/scope.rb
+++ b/lib/katakata_irb/scope.rb
@@ -232,7 +232,8 @@ module KatakataIrb
       end
       merge.each do |name, values|
         values << self[name] unless values.size == branches.size
-        self[name] = KatakataIrb::Types::UnionType[*values.compact]
+        values.compact!
+        self[name] = KatakataIrb::Types::UnionType[*values.compact] unless values.empty?
       end
     end
   end

--- a/lib/katakata_irb/scope.rb
+++ b/lib/katakata_irb/scope.rb
@@ -119,6 +119,7 @@ module KatakataIrb
     end
 
     def terminate
+      return if terminated?
       @terminated = true
       @changes = {}
     end
@@ -132,7 +133,8 @@ module KatakataIrb
     end
 
     def level_of(name)
-      has_own?(name) ? level : parent.level_of(name)
+      variable_level, = @changes[name]
+      variable_level || parent.level_of(name)
     end
 
     def [](name)
@@ -208,7 +210,6 @@ module KatakataIrb
     end
 
     def update(child_scope)
-      terminate if child_scope.terminated?
       current_level = level
       child_scope.mergeable_changes.each do |name, (level, value)|
         self[name] = value if level <= current_level

--- a/lib/katakata_irb/scope.rb
+++ b/lib/katakata_irb/scope.rb
@@ -177,6 +177,13 @@ module KatakataIrb
       block.call Scope.new(self, { BREAK_RESULT => nil, NEXT_RESULT => nil, PATTERNMATCH_BREAK => nil, RETURN_RESULT => nil, RAISE_BREAK => nil }, passthrough: true)
     end
 
+    def run(*args, **option)
+      scope = Scope.new(self, *args, **option)
+      yield scope
+      merge_jumps
+      update scope
+    end
+
     def run_branches(*blocks)
       results = []
       branches = []

--- a/lib/katakata_irb/type_simulator.rb
+++ b/lib/katakata_irb/type_simulator.rb
@@ -555,7 +555,7 @@ class KatakataIrb::TypeSimulator
   end
 
   def match_pattern(target, pattern, scope)
-    breakable = -> { scope.store_jump KatakataIrb::Scope::PATTERNMATCH_BREAK }
+    breakable = -> { scope.terminate_with KatakataIrb::Scope::PATTERNMATCH_BREAK, KatakataIrb::Types::NIL }
     types = target.types
     case pattern
     in [:var_field, [:@ident, name,]]

--- a/lib/katakata_irb/type_simulator.rb
+++ b/lib/katakata_irb/type_simulator.rb
@@ -87,7 +87,7 @@ class KatakataIrb::TypeSimulator
           trace_lvar: false
         )
         evaluate_assign_params params, [], method_scope
-        method_scope.conditional { evaluate_param_defaults params, method_scope }
+        method_scope.conditional { evaluate_param_defaults params, _1 }
         simulate_evaluate body_stmt, method_scope
       end
       KatakataIrb::Types::SYMBOL
@@ -238,7 +238,7 @@ class KatakataIrb::TypeSimulator
         return KatakataIrb::Types::NIL
       end
       receiver_type = receiver ? simulate_evaluate(receiver, scope) : scope.self_type
-      evaluate_method = lambda do
+      evaluate_method = lambda do |scope|
         args_type = args.map do |arg|
           if arg in KatakataIrb::Types::Splat
             simulate_evaluate arg.item, scope
@@ -257,7 +257,7 @@ class KatakataIrb::TypeSimulator
           elsif block in [:do_block | :brace_block => type, block_var, body]
             block_var in [:block_var, params,]
             call_block_proc = ->(block_args) do
-              result, breaks, nexts = scope.conditional do
+              result, breaks, nexts = scope.conditional do |s|
                 if params
                   names = extract_param_names(params)
                 else
@@ -265,9 +265,9 @@ class KatakataIrb::TypeSimulator
                   params = [:params, names.map { [:@ident, _1, [0, 0]] }, nil, nil, nil, nil, nil, nil]
                 end
                 params_table = names.zip(block_args).to_h { [_1, _2 || KatakataIrb::Types::NIL] }
-                block_scope = KatakataIrb::Scope.new scope, { **params_table, KatakataIrb::Scope::BREAK_RESULT => nil, KatakataIrb::Scope::NEXT_RESULT => nil }
+                block_scope = KatakataIrb::Scope.new s, { **params_table, KatakataIrb::Scope::BREAK_RESULT => nil, KatakataIrb::Scope::NEXT_RESULT => nil }
                 evaluate_assign_params params, block_args, block_scope
-                block_scope.conditional { evaluate_param_defaults params, block_scope } if params
+                block_scope.conditional { evaluate_param_defaults params, _1 } if params
                 if type == :do_block
                   result = simulate_evaluate body, block_scope
                 else
@@ -287,23 +287,23 @@ class KatakataIrb::TypeSimulator
         simulate_call receiver_type, method, args_type, kwargs_type(kwargs, scope), call_block_proc
       end
       if optional_chain
-        result = scope.conditional { evaluate_method.call }
+        result = scope.conditional { evaluate_method.call _1 }
         if receiver_type.nillable?
           KatakataIrb::Types::UnionType[result, KatakataIrb::Types::NIL]
         else
           result
         end
       else
-        evaluate_method.call
+        evaluate_method.call scope
       end
     in [:binary, a, Symbol => op, b]
       atype = simulate_evaluate a, scope
       case op
       when :'&&', :and
-        btype = scope.conditional { simulate_evaluate b, scope }
+        btype = scope.conditional { simulate_evaluate b, _1 }
         KatakataIrb::Types::UnionType[btype, KatakataIrb::Types::NIL, KatakataIrb::Types::FALSE]
       when :'||', :or
-        btype = scope.conditional { simulate_evaluate b, scope }
+        btype = scope.conditional { simulate_evaluate b, _1 }
         KatakataIrb::Types::UnionType[atype, btype]
       else
         btype = simulate_evaluate b, scope
@@ -317,10 +317,10 @@ class KatakataIrb::TypeSimulator
       params in [:paren, params]
       params_table = extract_param_names(params).to_h { [_1, KatakataIrb::Types::NIL] }
       block_scope = KatakataIrb::Scope.new scope, { **params_table, KatakataIrb::Scope::BREAK_RESULT => nil, KatakataIrb::Scope::NEXT_RESULT => nil, KatakataIrb::Scope::RETURN_RESULT => nil }
-      block_scope.conditional do
-        evaluate_assign_params params, [], block_scope
-        block_scope.conditional { evaluate_param_defaults params, block_scope }
-        statements.each { simulate_evaluate _1, block_scope }
+      block_scope.conditional do |s|
+        evaluate_assign_params params, [], s
+        s.conditional { evaluate_param_defaults params, _1 }
+        statements.each { simulate_evaluate _1, s }
       end
       block_scope.merge_jumps
       KatakataIrb::Types::ProcType.new
@@ -370,30 +370,30 @@ class KatakataIrb::TypeSimulator
     in [:ifop, cond, tval, fval]
       simulate_evaluate cond, scope
       KatakataIrb::Types::UnionType[*scope.run_branches(
-        -> { simulate_evaluate tval, scope },
-        -> { simulate_evaluate fval, scope }
+        -> { simulate_evaluate tval, _1 },
+        -> { simulate_evaluate fval, _1 }
       )]
     in [:if_mod | :unless_mod, cond, statement]
       simulate_evaluate cond, scope
-      KatakataIrb::Types::UnionType[scope.conditional { simulate_evaluate statement, scope }, KatakataIrb::Types::NIL]
+      KatakataIrb::Types::UnionType[scope.conditional { simulate_evaluate statement, _1 }, KatakataIrb::Types::NIL]
     in [:if | :unless | :elsif, cond, statements, else_statement]
       simulate_evaluate cond, scope
       results = scope.run_branches(
-        -> { statements.map { simulate_evaluate _1, scope }.last },
-        -> { else_statement ? simulate_evaluate(else_statement, scope) : KatakataIrb::Types::NIL }
+        ->(s) { statements.map { simulate_evaluate _1, s }.last },
+        ->(s) { else_statement ? simulate_evaluate(else_statement, s) : KatakataIrb::Types::NIL }
       )
       results.empty? ? KatakataIrb::Types::NIL : KatakataIrb::Types::UnionType[*results]
     in [:while | :until, cond, statements]
       inner_scope = KatakataIrb::Scope.new scope, { KatakataIrb::Scope::BREAK_RESULT => nil }, passthrough: true
       simulate_evaluate cond, inner_scope
-      inner_scope.conditional { statements.each { simulate_evaluate _1, inner_scope } }
+      inner_scope.conditional { |s| statements.each { simulate_evaluate _1, s } }
       inner_scope.merge_jumps
       breaks = inner_scope[KatakataIrb::Scope::BREAK_RESULT]
       breaks ? KatakataIrb::Types::UnionType[breaks, KatakataIrb::Types::NIL] : KatakataIrb::Types::NIL
     in [:while_mod | :until_mod, cond, statement]
       inner_scope = KatakataIrb::Scope.new scope, { KatakataIrb::Scope::BREAK_RESULT => nil }, passthrough: true
       simulate_evaluate cond, inner_scope
-      scope.conditional { simulate_evaluate statement, inner_scope }
+      inner_scope.conditional { |s| simulate_evaluate statement, s }
       inner_scope.merge_jumps
       breaks = inner_scope[KatakataIrb::Scope::BREAK_RESULT]
       breaks ? KatakataIrb::Types::UnionType[breaks, KatakataIrb::Types::NIL] : KatakataIrb::Types::NIL
@@ -436,32 +436,32 @@ class KatakataIrb::TypeSimulator
       return_type = statements.map { simulate_evaluate _1, rescue_scope || scope }.last
       rescue_scope&.merge_jumps
       if rescue_stmt
-        return_type = KatakataIrb::Types::UnionType[return_type, scope.conditional { simulate_evaluate rescue_stmt, scope }]
+        return_type = KatakataIrb::Types::UnionType[return_type, scope.conditional { |s| simulate_evaluate rescue_stmt, s }]
       end
       simulate_evaluate ensure_stmt, scope if ensure_stmt
       return_type
     in [:rescue, error_class_stmts, error_var_stmt, statements, rescue_stmt]
-      return_type = scope.conditional do
+      return_type = scope.conditional do |s|
         if error_var_stmt in [:var_field, [:@ident, error_var,]]
           if (error_class_stmts in [:mrhs_new_from_args, Array => stmts, stmt])
             error_class_stmts = [*stmts, stmt]
           end
-          error_classes = (error_class_stmts || []).flat_map { simulate_evaluate _1, scope }.uniq
+          error_classes = (error_class_stmts || []).flat_map { simulate_evaluate _1, s }.uniq
           error_types = error_classes.filter_map { KatakataIrb::Types::InstanceType.new _1.module_or_class if _1 in KatakataIrb::Types::SingletonType }
           error_types << KatakataIrb::Types::InstanceType.new(StandardError) if error_types.empty?
-          scope[error_var] = KatakataIrb::Types::UnionType[*error_types]
+          s[error_var] = KatakataIrb::Types::UnionType[*error_types]
         end
-        statements.map { simulate_evaluate _1, scope }.last
+        statements.map { simulate_evaluate _1, s }.last
       end
       if rescue_stmt
-        return_type = KatakataIrb::Types::UnionType[return_type, scope.conditional { simulate_evaluate rescue_stmt, scope }]
+        return_type = KatakataIrb::Types::UnionType[return_type, scope.conditional { simulate_evaluate rescue_stmt, _1 }]
       end
       return_type
     in [:rescue_mod, statement1, statement2]
       rescue_scope = KatakataIrb::Scope.new scope, { KatakataIrb::Scope::RAISE_BREAK => nil }, passthrough: true
       a = simulate_evaluate statement1, rescue_scope
       rescue_scope.merge_jumps
-      b = scope.conditional { simulate_evaluate statement2, scope }
+      b = scope.conditional { simulate_evaluate statement2, _1 }
       KatakataIrb::Types::UnionType[a, b]
     in [:module, module_stmt, body_stmt]
       module_types = simulate_evaluate(module_stmt, scope).types.grep(KatakataIrb::Types::SingletonType)
@@ -489,29 +489,29 @@ class KatakataIrb::TypeSimulator
       response = simulate_call enum, :first, [], nil, nil
       evaluate_assign_params params, [response], scope
       inner_scope = KatakataIrb::Scope.new scope, { KatakataIrb::Scope::BREAK_RESULT => nil }, passthrough: true
-      scope.conditional do
-        statements.each { simulate_evaluate _1, inner_scope }
+      scope.conditional do |s|
+        statements.each { simulate_evaluate _1, s }
       end
       inner_scope.merge_jumps
       breaks = inner_scope[KatakataIrb::Scope::BREAK_RESULT]
       breaks ? KatakataIrb::Types::UnionType[breaks, enum] : enum
     in [:when, pattern, if_statements, else_statement]
-      eval_pattern = lambda do |pattern, *rest|
-        simulate_evaluate pattern, scope
-        scope.conditional { eval_pattern.call(*rest) } if rest.any?
+      eval_pattern = lambda do |s, pattern, *rest|
+        simulate_evaluate pattern, s
+        scope.conditional { eval_pattern.call(_1, *rest) } if rest.any?
       end
-      if_branch = lambda do
-        eval_pattern.call(*pattern)
-        if_statements.map { simulate_evaluate _1, scope }.last
+      if_branch = lambda do |s|
+        eval_pattern.call(s, *pattern)
+        if_statements.map { simulate_evaluate _1, s }.last
       end
-      else_branch = lambda do
-        pattern.each { simulate_evaluate _1, scope }
-        simulate_evaluate(else_statement, scope, case_target: case_target)
+      else_branch = lambda do |s|
+        pattern.each { simulate_evaluate _1, s }
+        simulate_evaluate(else_statement, s, case_target: case_target)
       end
       if if_statements && else_statement
         KatakataIrb::Types::UnionType[*scope.run_branches(if_branch, else_branch)]
       else
-        KatakataIrb::Types::UnionType[scope.conditional { (if_branch || else_branch).call }, KatakataIrb::Types::NIL]
+        KatakataIrb::Types::UnionType[scope.conditional { (if_branch || else_branch).call _1 }, KatakataIrb::Types::NIL]
       end
     in [:in, [:var_field, [:@ident, name,]], if_statements, else_statement]
       scope.never { simulate_evaluate else_statement, scope } if else_statement
@@ -519,16 +519,16 @@ class KatakataIrb::TypeSimulator
       if_statements ? if_statements.map { simulate_evaluate _1, scope }.last : KatakataIrb::Types::NIL
     in [:in, pattern, if_statements, else_statement]
       pattern_scope = KatakataIrb::Scope.new(scope, { KatakataIrb::Scope::PATTERNMATCH_BREAK => nil }, passthrough: true)
-      results = scope.run_branches(
-        -> {
-          match_pattern case_target, pattern, pattern_scope
-          if_statements ? if_statements.map { simulate_evaluate _1, scope }.last : KatakataIrb::Types::NIL
+      results = pattern_scope.run_branches(
+        ->(s) {
+          match_pattern case_target, pattern, s
+          if_statements ? if_statements.map { simulate_evaluate _1, s }.last : KatakataIrb::Types::NIL
         },
-        -> {
-          pattern_scope.merge_jumps
-          else_statement ? simulate_evaluate(else_statement, scope, case_target: case_target) : KatakataIrb::Types::NIL
+        ->(s) {
+          else_statement ? simulate_evaluate(else_statement, s, case_target: case_target) : KatakataIrb::Types::NIL
         }
       )
+      pattern_scope.merge_jumps
       KatakataIrb::Types::UnionType[*results]
     in [:case, target_exp, match_exp]
       target = simulate_evaluate target_exp, scope
@@ -567,7 +567,7 @@ class KatakataIrb::TypeSimulator
       breakable.call
     in [:binary, lpattern, :|, rpattern]
       match_pattern target, lpattern, scope
-      scope.conditional { match_pattern target, rpattern, scope }
+      scope.conditional { match_pattern target, rpattern, _1 }
       breakable.call
     in [:binary, lpattern, :'=>', [:var_field, [:@ident, name,]] => rpattern]
       if lpattern in [:var_ref, [:@const, _const_name,]]

--- a/lib/katakata_irb/type_simulator.rb
+++ b/lib/katakata_irb/type_simulator.rb
@@ -192,7 +192,7 @@ class KatakataIrb::TypeSimulator
       statements.map { simulate_evaluate _1, scope }.last
     in [:const_path_ref, receiver, [:@const, name,]]
       r = simulate_evaluate receiver, scope
-      (r in KatakataIrb::Types::SingletonType) ? self.class.type_of { r.module_or_class.const_get name } : KatakataIrb::Types::NIL
+      (r in KatakataIrb::Types::SingletonType) ? KatakataIrb::BaseScope.type_of { r.module_or_class.const_get name } : KatakataIrb::Types::NIL
     in [:__var_ref_or_call, [type, name, pos]]
       sexp = scope.has?(name) ? [:var_ref, [type, name, pos]] : [:vcall, [:@ident, name, pos]]
       simulate_evaluate sexp, scope
@@ -564,7 +564,7 @@ class KatakataIrb::TypeSimulator
       elem = (KatakataIrb::Types::UnionType[*[beg_type, end_type].compact]).nonnillable
       KatakataIrb::Types::InstanceType.new Range, { Elem: elem }
     in [:top_const_ref, [:@const, name,]]
-      self.class.type_of { Object.const_get name }
+      KatakataIrb::BaseScope.type_of { Object.const_get name }
     in [:string_concat, a, b]
       simulate_evaluate a, scope
       simulate_evaluate b, scope
@@ -743,14 +743,6 @@ class KatakataIrb::TypeSimulator
       end
     end
     KatakataIrb::Types::InstanceType.new(Hash, K: KatakataIrb::Types::UnionType[*keys], V: KatakataIrb::Types::UnionType[*values])
-  end
-
-  def self.type_of(fallback: KatakataIrb::Types::OBJECT)
-    begin
-      KatakataIrb::Types.type_from_object yield
-    rescue
-      fallback
-    end
   end
 
   def retrieve_method_call(sexp)

--- a/test/test_scope.rb
+++ b/test/test_scope.rb
@@ -7,12 +7,12 @@ class TestScope < Minitest::Test
   NIL = Types::NIL
   A, B, C, D, E, F, G, H, I, J, K = ('A'..'K').map do |name|
     klass = Class.new
-    klass.define_singleton_method(:name) { name }
+    klass.define_singleton_method(:inspect) { name }
     Types::InstanceType.new(klass)
   end
 
-  def assert_types(expected_types, type)
-    assert_equal expected_types.map(&:klass).to_set, type.types.map(&:klass).to_set
+  def assert_type(expected_types, type)
+    assert_equal [*expected_types].map(&:klass).to_set, type.types.map(&:klass).to_set
   end
 
   def base_scope
@@ -30,7 +30,7 @@ class TestScope < Minitest::Test
     scope.conditional do |sub_scope|
       sub_scope['a'] = A
     end
-    assert_types [A, NIL], scope['a']
+    assert_type [A, NIL], scope['a']
   end
 
   def test_branch
@@ -41,11 +41,52 @@ class TestScope < Minitest::Test
       -> { _1['a'] = _1['c'] = _1['d'] = C },
       -> { _1['a'] = _1['b'] = _1['d'] = D },
       -> { _1['a'] = _1['b'] = _1['d'] = E },
-      -> { _1['a'] = _1['b'] = _1['c'] = _1['d'] = F; _1.terminate }
+      -> { _1['a'] = _1['b'] = _1['c'] = F; _1.terminate }
     )
-    assert_types [C, D, E], scope['a']
-    assert_types [NIL, D, E], scope['b']
-    assert_types [A, C], scope['c']
-    assert_types [C, D, E], scope['d']
+    assert_type [C, D, E], scope['a']
+    assert_type [NIL, D, E], scope['b']
+    assert_type [A, C], scope['c']
+    assert_type [C, D, E], scope['d']
+  end
+
+  def test_nested_scope
+    scope = Scope.new base_scope
+    scope['a'] = A
+    scope['b'] = A
+    scope['c'] = A
+    sub_scope = Scope.new scope, { 'c' => B }
+    assert_type A, sub_scope['a']
+
+    assert_type A, sub_scope['b']
+    assert_type B, sub_scope['c']
+    sub_scope['a'] = C
+    sub_scope.conditional { _1['b'] = C }
+    sub_scope['c'] = C
+    assert_type C, sub_scope['a']
+    assert_type [A, C], sub_scope['b']
+    assert_type C, sub_scope['c']
+    scope.update sub_scope
+    assert_type C, scope['a']
+    assert_type [A, C], scope['b']
+    assert_type A, scope['c']
+  end
+
+  def test_break
+    scope = Scope.new base_scope
+    scope['a'] = A
+    breakable_scope = Scope.new scope, { Scope::BREAK_RESULT => nil }
+    breakable_scope.conditional do |sub|
+      sub['a'] = B
+      assert_type [B], sub['a']
+      sub.terminate_with Scope::BREAK_RESULT, C
+      sub['a'] = C
+      assert_type [C], sub['a']
+    end
+    assert_type [A], breakable_scope['a']
+    breakable_scope[Scope::BREAK_RESULT] = D
+    breakable_scope.merge_jumps
+    assert_type [C, D], breakable_scope[Scope::BREAK_RESULT]
+    scope.update breakable_scope
+    assert_type [A, B], scope['a']
   end
 end

--- a/test/test_scope.rb
+++ b/test/test_scope.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class TestScope < Minitest::Test
+  Types = KatakataIrb::Types
+  BaseScope = KatakataIrb::BaseScope
+  Scope = KatakataIrb::Scope
+  NIL = Types::NIL
+  A, B, C, D, E, F, G, H, I, J, K = ('A'..'K').map do |name|
+    klass = Class.new
+    klass.define_singleton_method(:name) { name }
+    Types::InstanceType.new(klass)
+  end
+
+  def assert_types(expected_types, type)
+    assert_equal expected_types.map(&:klass).to_set, type.types.map(&:klass).to_set
+  end
+
+  def base_scope
+    BaseScope.new(binding, Object.new)
+  end
+
+  def test_lvar
+    scope = Scope.new base_scope
+    scope['a'] = A
+    assert_equal A, scope['a']
+  end
+
+  def test_conditional
+    scope = Scope.new base_scope
+    scope.conditional do |sub_scope|
+      sub_scope['a'] = A
+    end
+    assert_types [A, NIL], scope['a']
+  end
+
+  def test_branch
+    scope = Scope.new base_scope
+    scope['c'] = A
+    scope['d'] = B
+    scope.run_branches(
+      -> { _1['a'] = _1['c'] = _1['d'] = C },
+      -> { _1['a'] = _1['b'] = _1['d'] = D },
+      -> { _1['a'] = _1['b'] = _1['d'] = E },
+      -> { _1['a'] = _1['b'] = _1['c'] = _1['d'] = F; _1.terminate }
+    )
+    assert_types [C, D, E], scope['a']
+    assert_types [NIL, D, E], scope['b']
+    assert_types [A, C], scope['c']
+    assert_types [C, D, E], scope['d']
+  end
+end

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -84,14 +84,14 @@ class TestTypeAnalyzeIrb < Minitest::Test
   end
 
   def test_block_next
-    assert_call('nil.then{1}.', include: Integer, exclude: NilClass)
-    assert_call('nil.then{next 1; 1.0}.', include: Integer, exclude: [Float, NilClass])
-    assert_call('nil.then{next 1; next 1.0}.', include: Integer, exclude: [Float, NilClass])
-    assert_call('nil.then{1 if cond}.', include: [Integer, NilClass])
-    assert_call('nil.then{if cond; 1; else; 1.0; end}.', include: [Integer, Float], exclude: NilClass)
-    assert_call('nil.then{next 1 if cond; 1.0}.', include: [Integer, Float], exclude: NilClass)
-    assert_call('nil.then{if cond; next 1; else; next 1.0; end; "a"}.', include: [Integer, Float], exclude: [String, NilClass])
-    assert_call('nil.then{if cond; next 1; else; next 1.0; end; next "a"}.', include: [Integer, Float], exclude: [String, NilClass])
+    assert_call('nil.then{1}.', include: Integer, exclude: [NilClass, Object])
+    assert_call('nil.then{next 1; 1.0}.', include: Integer, exclude: [Float, NilClass, Object])
+    assert_call('nil.then{next 1; next 1.0}.', include: Integer, exclude: [Float, NilClass, Object])
+    assert_call('nil.then{1 if cond}.', include: [Integer, NilClass], exclude: Object)
+    assert_call('nil.then{if cond; 1; else; 1.0; end}.', include: [Integer, Float], exclude: [NilClass, Object])
+    assert_call('nil.then{next 1 if cond; 1.0}.', include: [Integer, Float], exclude: [NilClass, Object])
+    assert_call('nil.then{if cond; next 1; else; next 1.0; end; "a"}.', include: [Integer, Float], exclude: [String, NilClass, Object])
+    assert_call('nil.then{if cond; next 1; else; next 1.0; end; next "a"}.', include: [Integer, Float], exclude: [String, NilClass, Object])
   end
 
   def test_vars_with_branch_termination

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -83,7 +83,18 @@ class TestTypeAnalyzeIrb < Minitest::Test
     assert_call('1.tap{if cond; break :a; else; break "a"; end}.', include: [Symbol, Integer, String], exclude: NilClass)
   end
 
-  def test_branch_termination
+  def test_block_next
+    assert_call('nil.then{1}.', include: Integer, exclude: NilClass)
+    assert_call('nil.then{next 1; 1.0}.', include: Integer, exclude: [Float, NilClass])
+    assert_call('nil.then{next 1; next 1.0}.', include: Integer, exclude: [Float, NilClass])
+    assert_call('nil.then{1 if cond}.', include: [Integer, NilClass])
+    assert_call('nil.then{if cond; 1; else; 1.0; end}.', include: [Integer, Float], exclude: NilClass)
+    assert_call('nil.then{next 1 if cond; 1.0}.', include: [Integer, Float], exclude: NilClass)
+    assert_call('nil.then{if cond; next 1; else; next 1.0; end; "a"}.', include: [Integer, Float], exclude: [String, NilClass])
+    assert_call('nil.then{if cond; next 1; else; next 1.0; end; next "a"}.', include: [Integer, Float], exclude: [String, NilClass])
+  end
+
+  def test_vars_with_branch_termination
     assert_call('a=1; tap{break; a=//}; a.', include: Integer, exclude: Regexp)
     assert_call('a=1; tap{a=1.0; break; a=//}; a.', include: [Integer, Float], exclude: Regexp)
     assert_call('a=1; tap{next; a=//}; a.', include: Integer, exclude: Regexp)

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -108,11 +108,11 @@ class TestTypeAnalyzeIrb < Minitest::Test
     assert_call('a=1; ->{ if cond; a=:a; break; a=""; end; a=// }; a.', include: [Integer, Symbol, Regexp], exclude: String)
     assert_call('a=1; ->{ if cond; a=:a; break; a=""; else; break; end; a=// }; a.', include: [Integer, Symbol], exclude: [String, Regexp])
 
-    # not implemented yet
-    # assert_call('a=1; tap{ a=1.0; break; a=// if cond; a.', include: [Regexp, Float], exclude: Integer)
-    # assert_call('a=1; tap{ a=1.0; next; a=// if cond; a.', include: [Regexp, Float], exclude: Integer)
-    # assert_call('a=1; ->{ a=1.0; break; a=// if cond; a.', include: [Regexp, Float], exclude: Integer)
-    # assert_call('a=1; while cond; a=1.0; break; a=// if cond; a.', include: [Regexp, Float], exclude: Integer)
+    # continue simulation on terminated branch
+    assert_call('a=1; tap{ a=1.0; break; a=// if cond; a.', include: [Regexp, Float], exclude: Integer)
+    assert_call('a=1; tap{ a=1.0; next; a=// if cond; a.', include: [Regexp, Float], exclude: Integer)
+    assert_call('a=1; ->{ a=1.0; break; a=// if cond; a.', include: [Regexp, Float], exclude: Integer)
+    assert_call('a=1; while cond; a=1.0; break; a=// if cond; a.', include: [Regexp, Float], exclude: Integer)
   end
 
   def test_to_str_to_int

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -75,8 +75,12 @@ class TestTypeAnalyzeIrb < Minitest::Test
     RUBY
   end
 
-  def test_conditional_break
+  def test_block_break
+    assert_call('1.tap{}.', include: [Integer], exclude: NilClass)
+    assert_call('1.tap{break :a; break "a"}.', include: [Symbol, Integer], exclude: [NilClass, String])
     assert_call('1.tap{break :a if b}.', include: [Symbol, Integer], exclude: NilClass)
+    assert_call('1.tap{break :a; break "a" if b}.', include: [Symbol, Integer], exclude: [NilClass, String])
+    assert_call('1.tap{if cond; break :a; else; break "a"; end}.', include: [Symbol, Integer, String], exclude: NilClass)
   end
 
   def test_branch_termination


### PR DESCRIPTION
class Scope(class that representing variable scope and branch) needs rearchitecture.


fixes
```ruby
self.then{next 1.0; 2.0}.method_complete # terminated branch's block response(2.0) should be ignored
 self.then{next 2}.method_complete # should not include OBJECT and INTEGER
a=1; tap{ break; return; next; a=""; a.method_complete } # should continue analyze on terminated branch
```

