### PR TITLE
Fix bug of lvar defined in dead branch

### DIFF
--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -166,17 +166,10 @@ class TestTypeAnalyzeIrb < Minitest::Test
   end
 
   def test_lvar_scope_complex
-    code = <<~RUBY
-      def f
-        if cond
-          return
-          if cond; return; a = 1; end
-        else
-          tap { a = :a }
-        end
-        a.
-    RUBY
-    assert_call(code, include: [NilClass, Symbol], exclude: [Integer, Object])
+    assert_call('if cond; a = 1; else; tap { a = :a }; end; a.', include: [NilClass, Integer, Symbol], exclude: [Object])
+    assert_call('def f; if cond; a = 1; return; end; tap { a = :a }; a.', include: [NilClass, Symbol], exclude: [Integer, Object])
+    assert_call('def f; if cond; return; a = 1; end; tap { a = :a }; a.', include: [NilClass, Symbol], exclude: [Integer, Object])
+    assert_call('def f; if cond; return; if cond; return; a = 1; end; end; tap { a = :a }; a.', include: [NilClass, Symbol], exclude: [Integer, Object])
   end
 
   def test_gvar_no_scope

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -165,6 +165,20 @@ class TestTypeAnalyzeIrb < Minitest::Test
     assert_call(code, include: [Hash, Integer, String], exclude: [Symbol])
   end
 
+  def test_lvar_scope_complex
+    code = <<~RUBY
+      def f
+        if cond
+          return
+          if cond; return; a = 1; end
+        else
+          tap { a = :a }
+        end
+        a.
+    RUBY
+    assert_call(code, include: [NilClass, Symbol], exclude: [Integer, Object])
+  end
+
   def test_gvar_no_scope
     code = <<~RUBY
       tap { $a = :maybe }


### PR DESCRIPTION
Fix these bug
```ruby
if cond
  return
  a = 1
end
tap { a = '' }
a #=> should be String | NilClass
```

```ruby
if cond
  a = 1
else
  tap { a = '' }
end
a #=> should be String | NilClass
```

Ripper.sexp does not have local variable table (RubyVM::AbstractSyntaxTree have them)
Changed to collect local variable assignment from all branch including dead ones(dead = terminated by break, return next).

