### PR TITLE
Specify min reline version, make it work in reline 0.3.1 and 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     katakata_irb (0.1.8)
       irb (>= 1.4.0)
       rbs
+      reline (>= 0.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/katakata_irb.gemspec
+++ b/katakata_irb.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency 'irb', '>= 1.4.0'
+  spec.add_dependency 'reline', '>= 0.3.0'
   spec.add_dependency 'rbs'
 
   # For more information and examples about making a new gem, check out our

--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -130,7 +130,8 @@ module KatakataIrb::Completor
       width = contents.map { Reline::Unicode.calculate_width _1 }.max
       x = cursor_pos_to_render.x + autocomplete_dialog.width
       y = cursor_pos_to_render.y
-      Reline::DialogRenderInfo.new(pos: Reline::CursorPos.new(x, y), contents: contents, width: width, bg_color: 44, fg_color: 37)
+      info = { pos: Reline::CursorPos.new(x, y), contents: contents, width: width, bg_color: 44, fg_color: 37 }
+      Reline::DialogRenderInfo.new(**info.slice(*Reline::DialogRenderInfo.members))
     }
     Reline.add_dialog_proc(:show_type, type_dialog_proc, Reline::DEFAULT_DIALOG_CONTEXT)
   end


### PR DESCRIPTION
Reline::DialogRenderInfo does not have fg_color in reline 0.3.0 and 0.3.1
Fixes #8