### PR TITLE
Use RBS for autocompletion of instance methods

### DIFF
--- a/lib/katakata_irb/types.rb
+++ b/lib/katakata_irb/types.rb
@@ -193,7 +193,10 @@ module KatakataIrb::Types
     def nillable?() = (@klass == NilClass)
     def nonnillable() = self
     def rbs_methods
-      type_name = RBS::TypeName(KatakataIrb::Types.class_name_of(@klass)).absolute!
+      name = KatakataIrb::Types.class_name_of(@klass)
+      return {} unless name
+
+      type_name = RBS::TypeName(name).absolute!
       KatakataIrb::Types.rbs_builder.build_instance(type_name).methods rescue {}
     end
     def inspect

--- a/lib/katakata_irb/types.rb
+++ b/lib/katakata_irb/types.rb
@@ -194,7 +194,7 @@ module KatakataIrb::Types
     def nonnillable() = self
     def rbs_methods
       type_name = RBS::TypeName(KatakataIrb::Types.class_name_of(@klass)).absolute!
-      KatakataIrb::Types.rbs_builder.build_instance(type_name).methods rescue []
+      KatakataIrb::Types.rbs_builder.build_instance(type_name).methods rescue {}
     end
     def inspect
       if params.empty?

--- a/lib/katakata_irb/types.rb
+++ b/lib/katakata_irb/types.rb
@@ -186,12 +186,16 @@ module KatakataIrb::Types
       @params = params
     end
     def transform() = yield(self)
-    def methods() = @klass.instance_methods
-    def all_methods() = @klass.instance_methods | @klass.private_instance_methods
+    def methods() = rbs_methods.select { _2.public? }.keys | @klass.instance_methods
+    def all_methods() = rbs_methods.keys | @klass.instance_methods | @klass.private_instance_methods
     def constants() = []
     def types() = [self]
     def nillable?() = (@klass == NilClass)
     def nonnillable() = self
+    def rbs_methods
+      type_name = RBS::TypeName(KatakataIrb::Types.class_name_of(@klass)).absolute!
+      KatakataIrb::Types.rbs_builder.build_instance(type_name).methods rescue []
+    end
     def inspect
       if params.empty?
         inspect_without_params


### PR DESCRIPTION
At present, KatakataIrb::Types::InstanceType lists the methods up from the class object using `#instance_method` method.  But that can't list the methods implemented via `#method_missing` up (ex. the attributes of ActiveRecord).

This uses RBS types to list the methods of instance up. It resolves the problem of ActiveRecord.


I'm newbie for both katakata_irb and RBS. So any feedback is welcome :-)
Thank you for the great software. I'm very excited to add katakata_irb to my toolkit!