### PR TITLE
Fix crash in tab-completion with --noautocomplete

### DIFF
--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -61,7 +61,7 @@ module KatakataIrb::Completor
     end
 
     IRB::InputCompletor.singleton_class.prepend Module.new{
-      def retrieve_completion_data(input, _bind: IRB.conf[:MAIN_CONTEXT].workspace.binding, doc_namespace: false)
+      def retrieve_completion_data(input, doc_namespace: false, **)
         return super unless doc_namespace
         name = input[/[a-zA-Z_0-9]+[!?=]?\z/]
         method_doc = -> type do

--- a/test/test_katakata_irb.rb
+++ b/test/test_katakata_irb.rb
@@ -39,6 +39,15 @@ class TestKatakataIrb < Minitest::Test
     end
   end
 
+  def test_irb_input_completor_compatibility
+    completion = IRB::InputCompletor.retrieve_completion_data 'at_exi', bind: binding, doc_namespace: false
+    assert_equal ['at_exit'], completion
+
+    KatakataIrb::Completor.prev_analyze_result = KatakataIrb::Completor.analyze 'a = 1.to_c; a.abs', binding
+    document = IRB::InputCompletor.retrieve_completion_data 'a.abs', bind: binding, doc_namespace: true
+    assert_equal 'Complex#abs', document
+  end
+
   SYNTAX_TEST_CODE_3_1_PLUS = <<~'RUBY'
     def f(*,**,&)
       f(&)


### PR DESCRIPTION
```
irb -r katakata_irb --noautocomplete
irb(main):001:0> 1.to_s[TAB][TAB]

#=> lib/katakata_irb/completor.rb:64:in `retrieve_completion_data': unknown keyword: :bind (ArgumentError)
```

Q. Why `--noautocomplete` is used with katakata_irb witch is a gem to provide powerful autocomplete?
A. Autocomplete is set to false by defualt in rails production
