### PR TITLE
Support loading types asynchronously

### DIFF
--- a/lib/katakata_irb.rb
+++ b/lib/katakata_irb.rb
@@ -1,5 +1,6 @@
 require 'katakata_irb/version'
 require 'katakata_irb/completor'
+require 'katakata_irb/types'
 
 module KatakataIrb
   class << self


### PR DESCRIPTION
To avoid the "Stop the world" on loading types, this allows to load types asynchronously.

Users can change the types loader via `KatakataIrb::Types.loader_type` setting:

    KatakataIrb::Types.loader_type = :async