### PR TITLE
Cache RBS Environment object

### DIFF
--- a/lib/katakata_irb/environment_loader.rb
+++ b/lib/katakata_irb/environment_loader.rb
@@ -1,0 +1,46 @@
+require 'rbs'
+require 'rbs/cli'
+
+module KatakataIrb
+  class EnvironmentLoader
+    CACHE_FILENAME = 'system.rbs'.freeze
+
+    attr_reader :loader
+
+    def load
+      @loader = RBS::CLI::LibraryOptions.new.loader
+      @loader.add path: Pathname('sig')
+      RBS::DefinitionBuilder.new env: load_env
+    end
+
+    def latest_modified_time
+      mtimes = []
+      loader.each_dir do |source, dir|
+        skip_hidden = !source.is_a?(Pathname)
+        mtimes << RBS::FileFinder.each_file(dir, skip_hidden: skip_hidden, immediate: true).map { |f| File.mtime(f) }.max
+      end
+      mtimes.max
+    end
+
+    def load_env
+      mtime = latest_modified_time
+      if cache_path.exist? && cache_path.mtime == mtime
+        new_loader = RBS::EnvironmentLoader.new(core_root: nil)
+        new_loader.add(path: cache_path)
+        RBS::Environment.from_loader(new_loader)
+      else
+        RBS::Environment.from_loader(loader).resolve_type_names.tap do |env|
+          cache_path.parent.mkpath
+          cache_path.open('wt') do |f|
+            RBS::Writer.new(out: f).write(env.declarations)
+          end
+          cache_path.utime(mtime, mtime)
+        end
+      end
+    end
+
+    def cache_path
+      @cache_path ||= Pathname(ENV['XDG_CACHE_HOME'] || File.expand_path('~/.cache')).join('katakata_irb', CACHE_FILENAME)
+    end
+  end
+end

--- a/lib/katakata_irb/types.rb
+++ b/lib/katakata_irb/types.rb
@@ -1,5 +1,5 @@
 require 'rbs'
-require 'rbs/cli'
+require 'katakata_irb/environment_loader'
 
 module KatakataIrb; end
 module KatakataIrb::Types
@@ -26,9 +26,7 @@ module KatakataIrb::Types
   end
 
   def self.load_rbs_builder
-    loader = RBS::CLI::LibraryOptions.new.loader
-    loader.add path: Pathname('sig')
-    RBS::DefinitionBuilder.new env: RBS::Environment.from_loader(loader).resolve_type_names
+    KatakataIrb::EnvironmentLoader.new.load
   rescue => e
     puts "\r\nKatakataIRB failed to initialize RBS::DefinitionBuilder\r\n#{e}\r\n"
     Object.new


### PR DESCRIPTION
To optimize the loading RBS Environment, this caches the resolved RBS environment object.  It will improve the performance of loading it twice if the cache is available (3.925s to 1.865s).  The cache will be invalidated automatically if the type definitions are changed.

As a penalty, the loading performance will be decreased twice if the cache is unavailable (3.925s to 7.981s) because generating cache file via `RBS::Writer` is very slow.

I'm not sure this is useful because this brings a bit heavy penalty.