### PR TITLE
Update nesting_parser (apply changes made in IRB::NestingParser)

### DIFF
--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -147,7 +147,7 @@ module KatakataIrb::Completor
     code = lvars_code + code
     tokens = RubyLex.ripper_lex_without_warning code
     tokens = KatakataIrb::NestingParser.interpolate_ripper_ignored_tokens code, tokens
-    last_opens = KatakataIrb::NestingParser.parse(tokens)
+    last_opens = KatakataIrb::NestingParser.open_tokens(tokens)
     closings = last_opens.map do |t|
       case t.tok
       when /\A%.[<>]\z/


### PR DESCRIPTION
NestingParser is merged to IRB (IRB::NestingParser) to fix IRB's indent bug and more.
This pull request updates KatakataIrb's Nesting parser, applied changes in review.

(some change (block parameter, ternary operator) is not included in IRB's version)