### PR TITLE
Remove broken code for loading rbs_builder

### DIFF
--- a/lib/katakata_irb/types.rb
+++ b/lib/katakata_irb/types.rb
@@ -22,7 +22,6 @@ module KatakataIrb::Types
         @rbs_builder = load_rbs_builder
       end
     end
-    rbs_builder_loader.run if @rbs_builder.nil?
   end
 
   def self.load_rbs_builder


### PR DESCRIPTION
`rbs_builder_loader` was already removed on the review at #15. Therefore it should be removed too.

Sorry for my bad. I've not noticed it because I've used "rescue StandardError" block to avoid the errors in the other environment...