### PR TITLE
fix percent literal completion: %<#{here}>

### DIFF
--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -150,7 +150,7 @@ module KatakataIrb::Completor
     last_opens = KatakataIrb::NestingParser.open_tokens(tokens)
     closings = last_opens.map do |t|
       case t.tok
-      when /\A%.[<>]\z/
+      when /\A%.?[<>]\z/
         $/ + '>'
       when '{', '#{', /\A%.?[{}]\z/
         $/ + '}'


### PR DESCRIPTION
Fix completion with percent literal with `<>`

```
irb> s = %<hello#{ 1.a█ }world>
```
