### PR TITLE
Support completion for optional chaining (&.)

### DIFF
--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -271,9 +271,12 @@ module KatakataIrb::Completor
       [:ivar, name, calculate_scope.call.self_type] if icvar_available
     in [:var_ref, [:@cvar,]]
       [:cvar, name, calculate_scope.call.self_type] if icvar_available
-    in [:call, receiver, [:@period,] | [:@op, '&.',] | :'::' => dot, [:@ident | :@const,]]
+    in [:call, receiver, [:@period,] | :'::' => dot, [:@ident | :@const,]]
       self_call = (receiver in [:var_ref, [:@kw, 'self',]])
       [dot == :'::' ? :call_or_const : :call, calculate_receiver.call(receiver), name, self_call]
+    in [:call, receiver, [:@op, '&.',], [:@ident | :@const,]]
+      self_call = (receiver in [:var_ref, [:@kw, 'self',]])
+      [:call, calculate_receiver.call(receiver).nonnillable, name, self_call]
     in [:const_path_ref, receiver, [:@const,]]
       [:const, calculate_receiver.call(receiver), name]
     in [:top_const_ref, [:@const,]]

--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -271,9 +271,12 @@ module KatakataIrb::Completor
       [:ivar, name, calculate_scope.call.self_type] if icvar_available
     in [:var_ref, [:@cvar,]]
       [:cvar, name, calculate_scope.call.self_type] if icvar_available
-    in [:call, receiver, [:@period,] | :'::' => dot, [:@ident | :@const,]]
+    in [:call, receiver, [:@op, '::',] | :'::', [:@ident | :@const,]]
       self_call = (receiver in [:var_ref, [:@kw, 'self',]])
-      [dot == :'::' ? :call_or_const : :call, calculate_receiver.call(receiver), name, self_call]
+      [:call_or_const, calculate_receiver.call(receiver), name, self_call]
+    in [:call, receiver, [:@period,], [:@ident | :@const,]]
+      self_call = (receiver in [:var_ref, [:@kw, 'self',]])
+      [:call, calculate_receiver.call(receiver), name, self_call]
     in [:call, receiver, [:@op, '&.',], [:@ident | :@const,]]
       self_call = (receiver in [:var_ref, [:@kw, 'self',]])
       [:call, calculate_receiver.call(receiver).nonnillable, name, self_call]

--- a/lib/katakata_irb/type_simulator.rb
+++ b/lib/katakata_irb/type_simulator.rb
@@ -769,9 +769,9 @@ class KatakataIrb::TypeSimulator
     case sexp
     in [:fcall | :vcall, [:@ident | :@const | :@kw | :@op, method,]] # hoge
       [nil, method, [], [], nil, false]
-    in [:call, receiver, [:@period,] | [:@op, '&.',] | :'::' => dot, :call]
+    in [:call, receiver, [:@period,] | [:@op, '&.',] | [:@op, '::',] | :'::' => dot, :call]
       [receiver, :call, [], [], nil, optional[dot]]
-    in [:call, receiver, [:@period,] | [:@op, '&.',] | :'::' => dot, method]
+    in [:call, receiver, [:@period,] | [:@op, '&.',] | [:@op, '::',] | :'::' => dot, method]
       method => [:@ident | :@const | :@kw | :@op, method,] unless method == :call
       [receiver, method, [], [], nil, optional[dot]]
     in [:command, [:@ident | :@const | :@kw | :@op, method,], args] # hoge 1, 2


### PR DESCRIPTION
The optional chaining allows to developers to call method only if the receiver is not nil.  Therefore, katakata_irb should consider the receiver is not nil if the optional chaining operator (&.) is given.

This fix unwraps the Optional[T] from receiver_type on completion for the optional chaining.  It will provide better completion for developers.

After:
![katakata_irb](https://github.com/tompng/katakata_irb/assets/748828/339b99dc-899c-431c-91fe-443b3b25bf6a)
