### PR TITLE
Support ruby3.3

### DIFF
--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -271,9 +271,12 @@ module KatakataIrb::Completor
       [:ivar, name, calculate_scope.call.self_type] if icvar_available
     in [:var_ref, [:@cvar,]]
       [:cvar, name, calculate_scope.call.self_type] if icvar_available
-    in [:call, receiver, [:@period,] | [:@op, '&.',] | :'::' => dot, [:@ident | :@const,]]
+    in [:call, receiver, [:@op, '::',] | :'::', [:@ident | :@const,]]
       self_call = (receiver in [:var_ref, [:@kw, 'self',]])
-      [dot == :'::' ? :call_or_const : :call, calculate_receiver.call(receiver), name, self_call]
+      [:call_or_const, calculate_receiver.call(receiver), name, self_call]
+    in [:call, receiver, [:@period,] | [:@op, '&.',], [:@ident | :@const,]]
+      self_call = (receiver in [:var_ref, [:@kw, 'self',]])
+      [:call, calculate_receiver.call(receiver), name, self_call]
     in [:const_path_ref, receiver, [:@const,]]
       [:const, calculate_receiver.call(receiver), name]
     in [:top_const_ref, [:@const,]]

--- a/lib/katakata_irb/type_simulator.rb
+++ b/lib/katakata_irb/type_simulator.rb
@@ -769,9 +769,9 @@ class KatakataIrb::TypeSimulator
     case sexp
     in [:fcall | :vcall, [:@ident | :@const | :@kw | :@op, method,]] # hoge
       [nil, method, [], [], nil, false]
-    in [:call, receiver, [:@period,] | [:@op, '&.',] | :'::' => dot, :call]
+    in [:call, receiver, [:@period,] | [:@op, '&.',] | [:@op, '::',] | :'::' => dot, :call]
       [receiver, :call, [], [], nil, optional[dot]]
-    in [:call, receiver, [:@period,] | [:@op, '&.',] | :'::' => dot, method]
+    in [:call, receiver, [:@period,] | [:@op, '&.',] | [:@op, '::',] | :'::' => dot, method]
       method => [:@ident | :@const | :@kw | :@op, method,] unless method == :call
       [receiver, method, [], [], nil, optional[dot]]
     in [:command, [:@ident | :@const | :@kw | :@op, method,], args] # hoge 1, 2


### PR DESCRIPTION
Since ruby3.3, the operator column of tCOLON2 node has been changed to `[:@op, '::']` from `:'::'`.  This handles it to support ruby3.3.

refs: https://github.com/ruby/ruby/pull/8144


I noticed the change here: https://github.com/tompng/katakata_irb/actions/runs/5869744338/job/15915379810?pr=21

Internally, I got the following error on my local (by debugging):

```
  1) Error:
TestKatakataIrb#test_analyze_does_not_raise_error:
NoMatchingPatternError: [:call, [:var_ref, [:@const, "RBS", [51, 18]]], [:@op, "::", [51, 21]], [:@const, "TypeName", [51, 23]]]
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:769:in `retrieve_method_call'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:784:in `retrieve_method_call'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:238:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:243:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:339:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:449:in `block in simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:449:in `map'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:449:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:277:in `block (3 levels) in simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/scope.rb:219:in `block in run_branches'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/scope.rb:217:in `each'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/scope.rb:217:in `run_branches'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/scope.rb:196:in `conditional'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:263:in `block (2 levels) in simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:867:in `simulate_call'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:297:in `block in simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:307:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:449:in `block in simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:449:in `map'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:449:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:92:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:449:in `block in simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:449:in `map'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:449:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:485:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:193:in `block in simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:193:in `map'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:193:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:243:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:63:in `block in simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:63:in `map'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:63:in `simulate_evaluate_inner'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:55:in `simulate_evaluate'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/type_simulator.rb:992:in `calculate_receiver'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/completor.rb:246:in `block in analyze'
    /Users/tkomiya/work/katakata_irb/lib/katakata_irb/completor.rb:276:in `analyze'
    /Users/tkomiya/work/katakata_irb/test/test_katakata_irb.rb:31:in `block in test_analyze_does_not_raise_error'
    /Users/tkomiya/work/katakata_irb/test/test_katakata_irb.rb:30:in `each'
    /Users/tkomiya/work/katakata_irb/test/test_katakata_irb.rb:30:in `test_analyze_does_not_raise_error'
```