### PR TITLE
Make rbs lazy loading default

### DIFF
--- a/test/test_katakata_irb.rb
+++ b/test/test_katakata_irb.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 
 # Needed for ruby 3.0 test
 Refinement = Object unless defined? Refinement
+KatakataIrb::Types.preload_in_thread.join
 
 class TestKatakataIrb < Minitest::Test
   def test_analyze_does_not_raise_error

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+KatakataIrb::Types.preload_in_thread.join
 
 class TestTypeAnalyze < Minitest::Test
   def empty_binding() = binding


### PR DESCRIPTION
Async loading configuration was introduced in https://github.com/tompng/katakata_irb/pull/15 because creating `RBS::DefinitionBuilder` could take few seconds.
This pull request makes async the only default loading strategy.

When loading
![スクリーンショット 2023-08-16 14 11 41](https://github.com/tompng/katakata_irb/assets/1780201/6a8dbaf8-b9dc-4de4-ba30-f376d5dc6a6d)
After Loading (need to reopen completion dialog again by delete or type something)
![スクリーンショット 2023-08-16 14 11 46](https://github.com/tompng/katakata_irb/assets/1780201/5fae0575-3e84-47e6-83bd-00fe631c366b)
