### PR TITLE
Tokenize without IRB's RubyLex

### DIFF
--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -153,8 +153,7 @@ module KatakataIrb::Completor
       "#{name}="
     end.join + "nil;\n"
     code = lvars_code + code
-    tokens = RubyLex.ripper_lex_without_warning code
-    tokens = KatakataIrb::NestingParser.interpolate_ripper_ignored_tokens code, tokens
+    tokens = KatakataIrb::NestingParser.tokenize code
     last_opens = KatakataIrb::NestingParser.open_tokens(tokens)
     closings = last_opens.map do |t|
       case t.tok

--- a/lib/katakata_irb/nesting_parser.rb
+++ b/lib/katakata_irb/nesting_parser.rb
@@ -1,4 +1,18 @@
 module KatakataIrb::NestingParser
+  ERROR_TOKENS = %i[
+    on_parse_error
+    compile_error
+    on_assign_error
+    on_alias_error
+    on_class_name_error
+    on_param_error
+  ]
+
+  def self.tokenize(code)
+    tokens = Ripper::Lexer.new(code).scan.reject { ERROR_TOKENS.include? _1.event }
+    KatakataIrb::NestingParser.interpolate_ripper_ignored_tokens code, tokens
+  end
+
   def self.interpolate_ripper_ignored_tokens(code, tokens)
     line_positions = code.lines.reduce([0]) { _1 << _1.last + _2.bytesize }
     prev_byte_pos = 0


### PR DESCRIPTION
RubyLex is deprecated (renamed to IRB::RubyLex)
