### PR TITLE
$VERBOSE=nil while analyzing

### DIFF
--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -53,12 +53,15 @@ module KatakataIrb::Completor
       end
     end
     IRB::InputCompletor::CompletionProc.define_singleton_method :call do |*args|
+      verbose, $VERBOSE = $VERBOSE, nil
       completion_proc.call(*args)
     rescue => e
       KatakataIrb.last_completion_error = e
       KatakataIrb.log_puts
       KatakataIrb.log_puts "#{e.inspect} stored to KatakataIrb.last_completion_error"
       KatakataIrb.log_puts
+    ensure
+      $VERBOSE = verbose
     end
 
     IRB::InputCompletor.singleton_class.prepend Module.new{

--- a/lib/katakata_irb/nesting_parser.rb
+++ b/lib/katakata_irb/nesting_parser.rb
@@ -9,8 +9,11 @@ module KatakataIrb::NestingParser
   ]
 
   def self.tokenize(code)
+    verbose, $VERBOSE = $VERBOSE, nil
     tokens = Ripper::Lexer.new(code).scan.reject { ERROR_TOKENS.include? _1.event }
     KatakataIrb::NestingParser.interpolate_ripper_ignored_tokens code, tokens
+  ensure
+    $VERBOSE = verbose
   end
 
   def self.interpolate_ripper_ignored_tokens(code, tokens)


### PR DESCRIPTION
This will print warning message
```
irb(main):001> /]]/.
↓
irb(main):001* /]]/.(ripper):2: warning: regular expression has ']' without escape: /]]/
```

Fix this by set `$VERBOSE = nil` before tokenizing and analyzing