### PR TITLE
Fix classname completion

### DIFF
--- a/lib/katakata_irb/type_simulator.rb
+++ b/lib/katakata_irb/type_simulator.rb
@@ -40,7 +40,7 @@ class KatakataIrb::TypeSimulator
 
   def evaluate(node, scope)
     result = evaluate_inner(node, scope)
-    @dig_targets.resolve result, scope if @dig_targets.target?(node)
+    @dig_targets.resolve result, scope if @dig_targets.target? node
     result
   end
 
@@ -691,6 +691,7 @@ class KatakataIrb::TypeSimulator
       name = node.name.to_s
       type = scope[name]
     end
+    @dig_targets.resolve type, scope if @dig_targets.target? node
     [type, receiver, parent_module, name]
   end
 

--- a/lib/katakata_irb/type_simulator.rb
+++ b/lib/katakata_irb/type_simulator.rb
@@ -490,8 +490,8 @@ class KatakataIrb::TypeSimulator
       return KatakataIrb::Types::NIL unless node.body
 
       table = node.locals.to_h { [_1.to_s, KatakataIrb::Types::NIL] }
-      if parent_module.is_a?(Module) || parent_module.nil?
-        value = parent_module.const_get name if parent_module&.const_defined?(name)
+      if !name.empty? && (parent_module.is_a?(Module) || parent_module.nil?)
+        value = parent_module.const_get name if parent_module&.const_defined? name
         unless value
           value_type = scope[name]
           value = value_type.module_or_class if value_type.is_a? KatakataIrb::Types::SingletonType

--- a/lib/katakata_irb/type_simulator.rb
+++ b/lib/katakata_irb/type_simulator.rb
@@ -474,7 +474,8 @@ class KatakataIrb::TypeSimulator
       result
     when Prism::ModuleNode, Prism::ClassNode
       unless node.constant_path.is_a?(Prism::ConstantReadNode) || node.constant_path.is_a?(Prism::ConstantPathNode)
-        # Syntax error code, example: `module a.b; end`
+        # Incomplete class/module `class (statement[cursor_here])::Name; end`
+        evaluate node.constant_path, scope
         return KatakataIrb::Types::NIL
       end
       const_type, _receiver, parent_module, name = evaluate_constant_node node.constant_path, scope

--- a/test/test_completion.rb
+++ b/test/test_completion.rb
@@ -48,6 +48,8 @@ class TestCompletor < Minitest::Test
     assert_completion('KatakataIrb::T', include: 'Types')
     assert_completion('FooBar=1; F', include: 'FooBar')
     assert_completion('::FooBar=1; ::F', include: 'FooBar')
+    assert_completion('::', include: 'Array')
+    assert_completion('class ::', include: 'Array')
   end
 
   def test_gvar

--- a/test/test_completion.rb
+++ b/test/test_completion.rb
@@ -50,6 +50,7 @@ class TestCompletor < Minitest::Test
     assert_completion('::FooBar=1; ::F', include: 'FooBar')
     assert_completion('::', include: 'Array')
     assert_completion('class ::', include: 'Array')
+    assert_completion('module KatakataIrb; class T', include: ['Types', 'TracePoint'])
   end
 
   def test_gvar

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -385,6 +385,8 @@ class TestTypeAnalyze < Minitest::Test
   end
 
   def test_class_module
+    assert_call('class (1.', include: Integer)
+    assert_call('class (a=1)::B; end; a.', include: Integer)
     assert_call('class Array; 1; end.', include: Integer)
     assert_call('class ::Array; 1; end.', include: Integer)
     assert_call('class Array::A; 1; end.', include: Integer)


### PR DESCRIPTION
Fixed these completions
```ruby
class (1.█; Array)::A
class ::█
class A; class B█
```