### PR TITLE
Fix forwarding arg bug

### DIFF
--- a/lib/katakata_irb/type_analyzer.rb
+++ b/lib/katakata_irb/type_analyzer.rb
@@ -797,7 +797,7 @@ class KatakataIrb::TypeAnalyzer
         # `f(a, ...)` treat like splat
         nil
       when Prism::SplatNode
-        evaluate arg.expression, scope
+        evaluate arg.expression, scope if arg.expression
         nil # TODO: splat
       else
         evaluate arg, scope
@@ -815,7 +815,7 @@ class KatakataIrb::TypeAnalyzer
             nil
           end
         when Prism::AssocSplatNode
-          evaluate arg.value, scope
+          evaluate arg.value, scope if arg.value
           nil
         end
       end.compact.to_h

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -354,6 +354,8 @@ class TestTypeAnalyze < Minitest::Test
     assert_call('def f(a,b=1,*c,d,x:0,y:,**z,&e); e.arity.', include: Integer)
     assert_call('def f(...); 1.', include: Integer)
     assert_call('def f(a,...); 1.', include: Integer)
+    assert_call('def f(...); g(...); 1.', include: Integer)
+    assert_call('def f(*,**,&); g(*,**,&); 1.', include: Integer)
     assert_call('class Array; def f; self.', include: Array)
   end
 


### PR DESCRIPTION
Fix completion error of `def f(*,**,&);g(*,**,&);1.`