### PR TITLE
Update for prism > 0.15.1

### DIFF
--- a/test/test_katakata_irb.rb
+++ b/test/test_katakata_irb.rb
@@ -57,9 +57,17 @@ class TestKatakataIrb < Minitest::Test
     codes = files.map do |file|
       File.read File.join(File.dirname(__FILE__), '../lib/katakata_irb', file)
     end
-    ignore_class_names = ['Prism::BlockLocalVariableNode', 'Prism::IndexAndWriteNode', 'Prism::IndexOperatorWriteNode', 'Prism::IndexOrWriteNode']
+    ignore_class_names = [
+      # Not traversed
+      'Prism::BlockLocalVariableNode',
+      # Added in prism 0.15.0
+      'Prism::IndexAndWriteNode', 'Prism::IndexOperatorWriteNode', 'Prism::IndexOrWriteNode',
+      # Removed in prism > 0.15.1
+      'Prism::RequiredDestructuredParameterNode'
+    ]
     implemented_node_class_names = [
       *codes.join.scan(/evaluate_[a-z_]+/).grep(/_node$/).map { "Prism::#{_1[9..].split('_').map(&:capitalize).join}" },
+      *codes.join.scan(/:[a-z_]+_node/).map { "Prism::#{_1[1..].split('_').map(&:capitalize).join}" },
       *codes.join.scan(/Prism::[A-Za-z]+Node/)
     ].uniq.sort - ignore_class_names
     all_node_class_names = Prism.constants.grep(/Node$/).map { "Prism::#{_1}" }.sort - ['Prism::Node'] - ignore_class_names

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -346,7 +346,7 @@ class TestTypeAnalyze < Minitest::Test
     assert_call('def (a="").f; end; a.', include: String)
     assert_call('def f(a=1); a.', include: Integer)
     assert_call('def f(**nil); 1.', include: Integer)
-    assert_call('def f(a,*b); *b.', include: Array)
+    assert_call('def f(a,*b); b.', include: Array)
     assert_call('def f(a,x:1); x.', include: Integer)
     assert_call('def f(a,x:,**); 1.', include: Integer)
     assert_call('def f(a,x:,**y); y.', include: Hash)


### PR DESCRIPTION
In the unreleased version of prism,
`Prism::RequiredDestructuredParameterNode` will be removed and change to `MultiTargetNode`
`Prism::HashPatternNode#assocs` is changed to elements and rest
`MultiWriteNode#targets` is split to lefts, rest, rights
Raw SplatNode is created for `*a.` (was raw MultiTargetNode)