### PR TITLE
Remove unused ProcType

### DIFF
--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -102,8 +102,6 @@ module KatakataIrb::Completor
             return KatakataIrb::Types.class_name_of(t.module_or_class)
           when KatakataIrb::Types::InstanceType
             return KatakataIrb::Types.class_name_of(t.klass)
-          when KatakataIrb::Types::ProcType
-            return 'Proc'
           end
         end
         nil

--- a/lib/katakata_irb/completor.rb
+++ b/lib/katakata_irb/completor.rb
@@ -290,8 +290,7 @@ module KatakataIrb::Completor
     )
     return [node] if location&.start_offset == position
 
-    node.child_nodes.each do |n|
-      next unless n.is_a? Prism::Node
+    node.compact_child_nodes.each do |n|
       match = find_target(n, position)
       next unless match
       match.unshift node

--- a/lib/katakata_irb/type_analyzer.rb
+++ b/lib/katakata_irb/type_analyzer.rb
@@ -434,7 +434,7 @@ class KatakataIrb::TypeAnalyzer
     end
     block_scope.merge_jumps
     scope.update block_scope
-    KatakataIrb::Types::ProcType.new
+    KatakataIrb::Types::PROC
   end
 
   def evaluate_reference_write(node, scope)

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -171,8 +171,15 @@ class TestTypeAnalyze < Minitest::Test
     RUBY
   end
 
+  def test_block
+    assert_call('nil.then{1}.', include: Integer, exclude: NilClass)
+    assert_call('nil.then(&:to_s).', include: String, exclude: NilClass)
+  end
+
   def test_block_break
     assert_call('1.tap{}.', include: [Integer], exclude: NilClass)
+    assert_call('1.tap{break :a}.', include: [Symbol, Integer], exclude: NilClass)
+    assert_call('1.tap{break :a, :b}[0].', include: Symbol)
     assert_call('1.tap{break :a; break "a"}.', include: [Symbol, Integer], exclude: [NilClass, String])
     assert_call('1.tap{break :a if b}.', include: [Symbol, Integer], exclude: NilClass)
     assert_call('1.tap{break :a; break "a" if b}.', include: [Symbol, Integer], exclude: [NilClass, String])
@@ -186,6 +193,8 @@ class TestTypeAnalyze < Minitest::Test
 
   def test_block_next
     assert_call('nil.then{1}.', include: Integer, exclude: [NilClass, Object])
+    assert_call('nil.then{next 1}.', include: Integer, exclude: [NilClass, Object])
+    assert_call('nil.then{next :a, :b}[0].', include: Symbol)
     assert_call('nil.then{next 1; 1.0}.', include: Integer, exclude: [Float, NilClass, Object])
     assert_call('nil.then{next 1; next 1.0}.', include: Integer, exclude: [Float, NilClass, Object])
     assert_call('nil.then{1 if cond}.', include: [Integer, NilClass], exclude: Object)


### PR DESCRIPTION
ProcType's arg type and return type was not implemented yet. 
`ProcType` and `InstanceType.new(Proc)` was mixed.
