### PR TITLE
Prism over 0.16.0

### DIFF
--- a/lib/katakata_irb/type_analyzer.rb
+++ b/lib/katakata_irb/type_analyzer.rb
@@ -918,10 +918,12 @@ class KatakataIrb::TypeAnalyzer
       scope[node.rest.name.to_s] = KatakataIrb::Types.array_of(*rest)
     end
     node.keywords.each do |n|
-      # n is Prism::KeywordParameterNode
+      # n is Prism::KeywordParameterNode (prism = 0.16.0)
+      # n is Prism::RequiredKeywordParameterNode | Prism::OptionalKeywordParameterNode (prism > 0.16.0)
       name = n.name.to_s.delete(':')
       values = [kwargs.delete(name)]
-      values << evaluate(n.value, scope) if n.value
+      # `respond_to?` is for prism > 0.16.0, `&& n.value` is for prism = 0.16.0
+      values << evaluate(n.value, scope) if n.respond_to?(:value) && n.value
       scope[name] = KatakataIrb::Types::UnionType[*values.compact]
     end
     # node.keyword_rest is Prism::KeywordRestParameterNode or Prism::ForwardingParameterNode or Prism::NoKeywordsParameterNode

--- a/test/test_katakata_irb.rb
+++ b/test/test_katakata_irb.rb
@@ -60,8 +60,10 @@ class TestKatakataIrb < Minitest::Test
     ignore_class_names = [
       # Not traversed
       'Prism::BlockLocalVariableNode',
-      # Removed in prism > 0.15.1
-      'Prism::RequiredDestructuredParameterNode'
+      # Removed in prism > 0.16.0
+      'Prism::KeywordParameterNode',
+      # Added in prism > 0.16.0
+      'Prism::OptionalKeywordParameterNode', 'Prism::RequiredKeywordParameterNode'
     ]
     implemented_node_class_names = [
       *codes.join.scan(/evaluate_[a-z_]+/).grep(/_node$/).map { "Prism::#{_1[9..].split('_').map(&:capitalize).join}" },

--- a/test/test_type_analyze.rb
+++ b/test/test_type_analyze.rb
@@ -314,6 +314,7 @@ class TestTypeAnalyze < Minitest::Test
     assert_call('a,*b=[1,2]; a.', include: Integer, exclude: Array)
     assert_call('a,*b=[1,2]; b.', include: Array, exclude: Integer)
     assert_call('a,*b=[1,2]; b.sample.', include: Integer)
+    assert_call('a,*,(*)=[1,2]; a.', include: Integer)
     assert_call('*a=[1,2]; a.', include: Array, exclude: Integer)
     assert_call('*a=[1,2]; a.sample.', include: Integer)
     assert_call('a,*b,c=[1,2,3]; b.', include: Array, exclude: Integer)
@@ -356,6 +357,7 @@ class TestTypeAnalyze < Minitest::Test
     assert_call('def (a="").f; end; a.', include: String)
     assert_call('def f(a=1); a.', include: Integer)
     assert_call('def f(**nil); 1.', include: Integer)
+    assert_call('def f((*),*); 1.', include: Integer)
     assert_call('def f(a,*b); b.', include: Array)
     assert_call('def f(a,x:1); x.', include: Integer)
     assert_call('def f(a,x:,**); 1.', include: Integer)
@@ -366,6 +368,8 @@ class TestTypeAnalyze < Minitest::Test
     assert_call('def f(a,...); 1.', include: Integer)
     assert_call('def f(...); g(...); 1.', include: Integer)
     assert_call('def f(*,**,&); g(*,**,&); 1.', include: Integer)
+    assert_call('def f(*,**,&); {**}.', include: Hash)
+    assert_call('def f(*,**,&); [*,**].', include: Array)
     assert_call('class Array; def f; self.', include: Array)
   end
 
@@ -465,6 +469,7 @@ class TestTypeAnalyze < Minitest::Test
     assert_call('true.', include: TrueClass)
     assert_call('false.', include: FalseClass)
     assert_call('nil.', include: NilClass)
+    assert_call('().', include: NilClass)
     assert_call('//.', include: Regexp)
     assert_call('/#{a=1}/.', include: Regexp)
     assert_call('/#{a=1}/; a.', include: Integer)
@@ -569,6 +574,7 @@ class TestTypeAnalyze < Minitest::Test
   def test_for
     assert_call('for i in [1,2,3]; i.', include: Integer)
     assert_call('for i,j in [1,2,3]; i.', include: Integer)
+    assert_call('for *,(*) in [1,2,3]; 1.', include: Integer)
     assert_call('for *i in [1,2,3]; i.sample.', include: Integer)
     assert_call('for (a=1).b in [1,2,3]; a.', include: Integer)
     assert_call('for Array::B in [1,2,3]; Array::B.', include: Integer)
@@ -674,6 +680,7 @@ class TestTypeAnalyze < Minitest::Test
     assert_call('[1,2,3].tap{|a,*b| b.', include: Array)
     assert_call('[1,2,3].tap{|a=1.0| a.', include: [Array, Float])
     assert_call('[1,2,3].tap{|a,**b| b.', include: Hash)
+    assert_call('1.tap{|(*),*,**| 1.', include: Integer)
   end
 
   def test_array_aref


### PR DESCRIPTION
Fix bug analyzing `[**]` `{**}` `[*]` `def f((*))` `tap{|(*)|`
`(Optional|Required)KeywordParameterNode` will be added and `KeywordParameterNode` will be removed